### PR TITLE
Feature/expand skelleton to endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,16 +1,16 @@
 package main
 
 import (
-	"buzzer/m/v2/route"
-	"github.com/gin-gonic/gin"
+    "buzzer/m/v2/route"
+    "github.com/gin-gonic/gin"
 )
 
 func main() {
-	r := gin.Default()
-	r.GET("/", route.GetEntry)
-	r.GET("/data", route.GetData)
-	r.GET("/admin", route.GetAdmin)
-	r.GET("/monitoring", route.GetMonitoring)
+    r := gin.Default()
+    r.GET("/", route.GetEntry)
+    r.GET("/data", route.GetData)
+    r.GET("/admin", route.GetAdmin)
+    r.GET("/monitoring", route.GetMonitoring)
 
-	r.Run(":3000")
+    r.Run(":3000")
 }

--- a/main.go
+++ b/main.go
@@ -1,13 +1,16 @@
 package main
 
-import "github.com/gin-gonic/gin"
+import (
+	"buzzer/m/v2/route"
+	"github.com/gin-gonic/gin"
+)
 
 func main() {
 	r := gin.Default()
-	r.GET("/ping", func(c *gin.Context) {
-		c.JSON(200, gin.H{
-			"message": "pong",
-		})
-	})
+	r.GET("/", route.GetEntry)
+	r.GET("/data", route.GetData)
+	r.GET("/admin", route.GetAdmin)
+	r.GET("/monitoring", route.GetMonitoring)
+
 	r.Run(":3000")
 }

--- a/route/admin.go
+++ b/route/admin.go
@@ -1,0 +1,9 @@
+package route
+
+import "github.com/gin-gonic/gin"
+
+func GetAdmin (c *gin.Context) {
+	c.JSON(200, gin.H{
+		"message": "pong",
+	})
+}

--- a/route/admin.go
+++ b/route/admin.go
@@ -3,7 +3,7 @@ package route
 import "github.com/gin-gonic/gin"
 
 func GetAdmin (c *gin.Context) {
-	c.JSON(200, gin.H{
-		"message": "pong",
-	})
+    c.JSON(200, gin.H{
+        "message": "pong",
+    })
 }

--- a/route/data.go
+++ b/route/data.go
@@ -3,7 +3,7 @@ package route
 import "github.com/gin-gonic/gin"
 
 func GetData (c *gin.Context) {
-	c.JSON(200, gin.H{
-		"message": "pong",
-	})
+    c.JSON(200, gin.H{
+        "message": "pong",
+    })
 }

--- a/route/data.go
+++ b/route/data.go
@@ -1,0 +1,9 @@
+package route
+
+import "github.com/gin-gonic/gin"
+
+func GetData (c *gin.Context) {
+	c.JSON(200, gin.H{
+		"message": "pong",
+	})
+}

--- a/route/entry.go
+++ b/route/entry.go
@@ -3,7 +3,7 @@ package route
 import "github.com/gin-gonic/gin"
 
 func GetEntry (c *gin.Context) {
-	c.JSON(200, gin.H{
-		"message": "pong",
-	})
+    c.JSON(200, gin.H{
+        "message": "pong",
+    })
 }

--- a/route/entry.go
+++ b/route/entry.go
@@ -1,0 +1,9 @@
+package route
+
+import "github.com/gin-gonic/gin"
+
+func GetEntry (c *gin.Context) {
+	c.JSON(200, gin.H{
+		"message": "pong",
+	})
+}

--- a/route/monitoring.go
+++ b/route/monitoring.go
@@ -1,0 +1,9 @@
+package route
+
+import "github.com/gin-gonic/gin"
+
+func GetMonitoring (c *gin.Context) {
+	c.JSON(200, gin.H{
+		"message": "pong",
+	})
+}

--- a/route/monitoring.go
+++ b/route/monitoring.go
@@ -3,7 +3,7 @@ package route
 import "github.com/gin-gonic/gin"
 
 func GetMonitoring (c *gin.Context) {
-	c.JSON(200, gin.H{
-		"message": "pong",
-	})
+    c.JSON(200, gin.H{
+        "message": "pong",
+    })
 }


### PR DESCRIPTION
# Description
Die Inhalte der Routen für die Webendpunkte werden ziemlich viele Lines of Code beinhalten und die Formatierung wird aktuell noch mit Tabs eingerückt.

# Solution
Die Endpunkte wurden in ein eigenes Modul und eigene Datein ausgelagert. Dies dient jedoch nur als Skellet für weitere Anpassungen.

# How to test
- Die Webentpunkte / , /admin , /data, /monitoring aufrufen
- Wenn keine Fehler entstehen, war der Test erfolgreich.